### PR TITLE
Hide data display if widget is loaded more than once

### DIFF
--- a/src/public/loader.html
+++ b/src/public/loader.html
@@ -158,6 +158,7 @@
             return true;
           },
           connect(){
+            this.data = null;
             this.finished = false;
             this.accounts = null;
             this.initWidget(this.action);


### PR DESCRIPTION
Old way. Once you load data, and restart the connect process, the data box shows under the widget:
<img width="1042" alt="image" src="https://github.com/Universal-Connect-Project/ucw-example/assets/1331818/edef75ad-0143-4e2c-b066-bd01d3265664">

New way, restarting the connect process hides the data box:
<img width="891" alt="image" src="https://github.com/Universal-Connect-Project/ucw-example/assets/1331818/88957d6c-25f9-42cf-b2f5-708c13382dcb">

